### PR TITLE
Support EVM chain data for composite charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 #### What ?
 
-
-
-This is a command line tool that generates composite instrument 
-charts. Currently, it uses binance's API, but the point is to 
-make this capable of working with decentralized exchanges as well. 
-Eventually I hope to be able to do something like: 
+This is a command line tool that generates composite instrument
+charts. It can pull market data from Binance via ccxt or directly
+from EVM chains using the Moralis Web3 API. With on-chain data you
+can compare liquidity pools across networks. For example:
 
 <pre>
 --evm --base arbitrum:0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f/0xaf88d065e77c8cC2239327C5EDb3A432268e5831 --quote base:0x63706e401c06ac8513145b7687A14804d17f814b/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
@@ -32,7 +30,13 @@ Only elite traders will understand why this is such a useful trick.
 
 
 <pre>
-python3 ./main.py --base BTC/USDT --quote ETH/USDT --interval 1h 
+python3 ./main.py --base BTC/USDT --quote ETH/USDT --interval 1h
+
+# on‑chain example (requires MORALIS_API_KEY env variable)
+python3 ./main.py --evm \
+    --base arbitrum:0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f/0xaf88d065e77c8cC2239327C5EDb3A432268e5831 \
+    --quote base:0x63706e401c06ac8513145b7687A14804d17f814b/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
+    --interval 1h
 </pre>
 
 

--- a/main.py
+++ b/main.py
@@ -25,11 +25,26 @@ class Binance(ccxt.binance):
         ]
 
 class CompositeGenerator:
-    def __init__(self):
-        self.exchange = Binance()
+    def __init__(self, use_evm: bool = False):
+        """Create generator.
+
+        Parameters
+        ----------
+        use_evm: bool
+            If True, market data will be fetched from an EVM chain via the
+            Moralis API instead of Binance.
+        """
+        self.use_evm = use_evm
+        if not self.use_evm:
+            # Only initialize the Binance exchange when needed to avoid
+            # requiring ccxt configuration for on-chain usage.
+            self.exchange = Binance()
 
     def fetch_klines(self, symbol: str, interval: str = '1h', lookback: int = 100):
+        """Fetch OHLCV data from the configured data source."""
         pd.set_option('future.no_silent_downcasting', True)
+        if self.use_evm:
+            return self.fetch_evm_klines(symbol, interval, lookback)
         klines = self.exchange.fetch_ohlcv(symbol, interval, limit=lookback)
         df = pd.DataFrame(klines, columns=[
             'Open Time', 'Open', 'High', 'Low', 'Close', 'Volume',
@@ -42,14 +57,50 @@ class CompositeGenerator:
             df[col] = df[col].astype(float)
         return df[['Open', 'High', 'Low', 'Close', 'Volume']]
 
+    def fetch_evm_klines(self, ticker: str, interval: str, lookback: int):
+        """Retrieve OHLCV data for an on-chain pair using Moralis."""
+        # Import lazily to keep Binance-only usage lightweight.
+        from moralis_oclh import MoralisApi
+
+        chain, tokens = ticker.split(':', 1)
+        token0, token1 = tokens.split('/')
+
+        pair_address = MoralisApi.get_pair_address(token0, token1, chain=chain, time_period=interval)
+        klines = MoralisApi.get_klines(chain, interval, lookback, pair_address)
+
+        df = pd.DataFrame(klines)
+        # Moralis returns timestamps in milliseconds under the `timestamp` key.
+        df['Open Time'] = pd.to_datetime(df['timestamp'], unit='ms')
+        df.set_index('Open Time', inplace=True)
+        df.rename(columns={
+            'open': 'Open',
+            'high': 'High',
+            'low': 'Low',
+            'close': 'Close',
+            'volume': 'Volume',
+        }, inplace=True)
+        for col in ['Open', 'High', 'Low', 'Close', 'Volume']:
+            if col in df.columns:
+                df[col] = df[col].astype(float)
+            else:
+                df[col] = 0.0
+        return df[['Open', 'High', 'Low', 'Close', 'Volume']]
+
+    def _extract_symbol_parts(self, ticker: str):
+        """Return sanitized symbol and quote components for labeling."""
+        if self.use_evm:
+            sym = ticker.replace(':', '_').replace('/', '_')
+            return sym, ''
+        symbol = ticker.split('/')[0]
+        quote = ticker.split('/')[1]
+        return symbol, quote
+
     def generate_chart(self, base_ticker, quote_ticker, interval, lookback):
         base_df = self.fetch_klines(base_ticker, interval, lookback)
         quote_df = self.fetch_klines(quote_ticker, interval, lookback)
 
-        base_symbol = base_ticker.split('/')[0]
-        base_quote = base_ticker.split('/')[1]
-        quote_symbol = quote_ticker.split('/')[0]
-        quote_quote = quote_ticker.split('/')[1]
+        base_symbol, base_quote = self._extract_symbol_parts(base_ticker)
+        quote_symbol, quote_quote = self._extract_symbol_parts(quote_ticker)
 
         merged_df = pd.merge(base_df, quote_df, left_index=True, right_index=True,
                              suffixes=(f'_{base_symbol}', f'_{quote_symbol}'))
@@ -131,8 +182,11 @@ def main():
     parser.add_argument('--quote', required=True, help='Quote asset ticker (e.g., BTC/USDT)')
     parser.add_argument('--interval', default='1h', help='Interval for candlesticks (default: 1h)')
     parser.add_argument('--lookback', default=100, type=int, help='Number of candles to fetch (default: 100)')
+    parser.add_argument('--evm', action='store_true', help='Fetch market data from an EVM chain via Moralis')
     args = parser.parse_args()
-    CompositeGenerator().generate_chart(args.base.upper(), args.quote.upper(), args.interval, args.lookback)
+    CompositeGenerator(use_evm=args.evm).generate_chart(
+        args.base.upper(), args.quote.upper(), args.interval, args.lookback
+    )
 
 if __name__ == '__main__':
     main()

--- a/moralis_oclh.py
+++ b/moralis_oclh.py
@@ -1,14 +1,25 @@
 import os
 
 import requests
-import dotenv
-from eth_typing import ChecksumAddress
+# Load environment variables if python-dotenv is available
+try:
+    import dotenv  # type: ignore
+    dotenv.load_dotenv()
+except Exception:
+    pass
+
+# moralis_oclh originally depended on eth_typing for ChecksumAddress.
+# To keep this module lightweight in environments where eth_typing isn't
+# installed, fall back to using simple strings for type hints.
+try:
+    from eth_typing import ChecksumAddress  # type: ignore
+except Exception:  # pragma: no cover - graceful fallback
+    ChecksumAddress = str  # type: ignore
 # from binance.ccxt.static_dependencies.ethereum import ChecksumAddress
 
 class OCLHFailError(Exception):
     pass
 
-dotenv.load_dotenv()
 API_KEY = os.environ.get('MORALIS_API_KEY')
 assert API_KEY is not None, 'MORALIS_API_KEY environment variable is not set'
 


### PR DESCRIPTION
## Summary
- allow `main.py` to fetch OHLCV data either from Binance or from EVM chains via Moralis
- make Moralis helper resilient to missing `eth_typing`/`dotenv`
- document on-chain usage and new `--evm` flag in README

## Testing
- `pip install TA-Lib`
- `pip install pandas ccxt mplfinance matplotlib`
- `python3 main.py --base BTC/USDT --quote ETH/USDT --interval 1h --lookback 5` *(fails: Network is unreachable)*
- `python3 main.py --evm --base arbitrum:0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f/0xaf88d065e77c8cC2239327C5EDb3A432268e5831 --quote base:0x63706e401c06ac8513145b7687A14804d17f814b/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 --interval 1h --lookback 5` *(fails: MORALIS_API_KEY environment variable is not set)*
- `python3 main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689e1fb61c1c8320b14117503e3c1165